### PR TITLE
Alejandro maya - Agregada sección de análisis de malware y criptografía #2

### DIFF
--- a/README_GRUPO_7.md
+++ b/README_GRUPO_7.md
@@ -42,3 +42,73 @@ Nuestro grupo escogió este repositorio por varias razones técnicas:
 Grupo 7  
 Maestría en Ciberseguridad  
 2025
+
+---
+### APORTE ALEJANDRO MAYA
+
+# 🛡️ Análisis de Vulnerabilidades y Técnicas de Seguridad - GRUPO 7
+
+## 📌 Análisis de Malware:
+
+El análisis de malware es el proceso de examinar software malicioso para entender su comportamiento, propósito y posibles efectos en un sistema o red. Este análisis puede ser:
+
+- **Estático**: Evaluación del malware sin ejecutarlo (por ejemplo, análisis de binarios, cadenas y código).
+- **Dinámico**: Observación del comportamiento del malware en tiempo de ejecución, normalmente en entornos aislados como sandboxes.
+
+El análisis permite a los equipos de ciberseguridad identificar nuevas amenazas, generar firmas para antivirus y entender cómo prevenir futuros ataques.
+
+### 🧰 Herramientas para análisis de malware
+
+- **Estático**:
+  - [Ghidra](https://ghidra-sre.org): Desensamblador y herramienta de ingeniería inversa.
+  - [Radare2](https://rada.re/n/): Framework de análisis binario.
+  - **Strings (Linux)**: Extrae texto legible desde archivos binarios.
+  - [Binwalk](https://github.com/ReFirmLabs/binwalk): Análisis de firmware y extracción de datos embebidos.
+
+- **Dinámico**:
+  - [Cuckoo Sandbox](https://cuckoosandbox.org): Sandbox automatizado para análisis de comportamiento.
+  - [ProcMon (Process Monitor)](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon): Monitoreo de procesos en tiempo real.
+  - [Wireshark](https://www.wireshark.org/): Análisis de tráfico de red.
+  - [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon): Monitoreo de eventos detallados del sistema.
+
+---
+
+## 🔐 Criptografía y Esteganografía
+
+### 🔒 Criptografía
+
+La criptografía es la ciencia de proteger la información mediante técnicas matemáticas que la transforman en datos ilegibles sin una clave de acceso. Se utiliza para garantizar la **confidencialidad**, **integridad**, **autenticación** y **no repudio** de la información.
+
+#### 🧰 Herramientas de criptografía
+
+- **OpenSSL**: Herramienta de línea de comandos para operaciones criptográficas.
+- **GPG (GNU Privacy Guard)**: Encriptación de archivos y correos con claves públicas y privadas.
+- **Hashcat**: Recuperación de contraseñas mediante ataques de fuerza bruta y diccionario.
+
+### 🕵️‍♂️ Esteganografía
+
+La esteganografía es el arte de ocultar información dentro de otro archivo (como imágenes, audio o video), de forma que su existencia pase desapercibida. A diferencia de la criptografía, su objetivo es la **ocultación**, no la encriptación.
+
+#### 🧰 Herramientas de esteganografía
+
+- **Steghide**: Inserta y extrae datos ocultos en imágenes o archivos de audio.
+- **zsteg**: Extrae datos ocultos de imágenes PNG y BMP.
+- **ExifTool**: Inspección y manipulación de metadatos donde puede ocultarse información.
+
+---
+
+## Referencias:
+
+- Sikorski, M., & Honig, A. (2012). *Practical Malware Analysis*. No Starch Press.
+- Paar, C., & Pelzl, J. (2010). *Understanding Cryptography*. Springer.
+- [OWASP Malware Analysis Project](https://owasp.org/www-project-malware-analysis/)
+- [Malware Unicorn RE101 Workshop](https://www.malwareunicorn.org/workshops/re101.html)
+- [Ghidra SRE](https://ghidra-sre.org/)
+- [Cuckoo Sandbox Docs](https://cuckoosandbox.readthedocs.io/)
+- [NSA Ghidra GitHub](https://github.com/NationalSecurityAgency/ghidra)
+- [OpenSSL Documentation](https://www.openssl.org/docs/)
+- [GNU Privacy Guard (GPG)](https://gnupg.org/)
+- [Steghide GitHub](https://github.com/StefanoDeVuono/steghide)
+- [ExifTool Documentation](https://exiftool.org/)
+
+---


### PR DESCRIPTION
Se agregó una nueva sección al README grupal con información sobre análisis de malware, criptografía y esteganografía.
Incluye herramientas comunes y referencias bibliográficas.
Este cambio tiene como objetivo enriquecer la documentación del repositorio con contenido técnico útil para los integrantes del grupo y otros usuarios interesados.
